### PR TITLE
Add DOI badge for Zenodo integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ This package provides distributed (a.k.a. partitioned) vectors and sparse matric
 | [![Build Status](https://github.com/PartitionedArrays/PartitionedArrays.jl/workflows/CI/badge.svg)](https://github.com/PartitionedArrays/PartitionedArrays.jl/actions) |
 |**Coverage** |
 | [![Coverage](https://codecov.io/gh/PartitionedArrays/PartitionedArrays.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/PartitionedArrays/PartitionedArrays.jl)|
-
+|**DOI** |
+| [![DOI](https://zenodo.org/badge/319607706.svg)](https://zenodo.org/badge/latestdoi/319607706)|
 
 
 ## Documentation


### PR DESCRIPTION
Fixes #185 

This adds a Zenodo DOI badge to the README. There is currently no actual zenodo DOI, since we need to make a release to get one. However, I have used the git repo id (from inspecting <https://api.github.com/repos/PartitionedArrays/PartitionedArrays.jl>) in the badge link, so it should start rendering the latest DOI once we tag a release.